### PR TITLE
Upgrade z3-solver version to 4.8.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = ['ply==3.11', 'toolz==0.9.0']
 try:
     import z3
 except ImportError:
-    requirements += ['z3-solver==4.8.0.0.post1']
+    requirements += ['z3-solver==4.8.10.0']
 
 _package_info = (
     _json.loads(_Path(__file__).parent.joinpath('hack_url_re', 'package_info.json').read_text()))


### PR DESCRIPTION
Upgrading z3-solver to a newer version since pip is not able to find a matching distribution for 4.8.0.0.post1 version.
```
ERROR: Could not find a version that satisfies the requirement z3-solver==4.8.0.0.post1
ERROR: No matching distribution found for z3-solver==4.8.0.0.post1
```